### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Ph4ntomByte/Portfolio/security/code-scanning/1](https://github.com/Ph4ntomByte/Portfolio/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not require write access to the repository contents, we can set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` has only the necessary access to perform the tasks in the workflow.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs unless overridden. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
